### PR TITLE
Update azure-pipelines-v2.yml

### DIFF
--- a/.ci/azure-pipelines-v2.yml
+++ b/.ci/azure-pipelines-v2.yml
@@ -1,10 +1,6 @@
 # MLHyperparameterTuning Pipeline 
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - master
+trigger: none
 
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
This script should not trigger AzGlobal on master commits. The build machines can't handle some of the differences.